### PR TITLE
Adds GH actions with lint and build step

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,11 +6,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: |
-          npm ci --ignore-scripts
-          npm run lint
+          yarn install --frozen-lockfile
+          yarn lint
   build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: npm ci --ignore-scripts
-      - run: npm run build
+      - run: yarn install --frozen-lockfile
+      - run: yarn build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,16 @@
+name: CI Checks
+on: push
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: |
+          npm ci --ignore-scripts
+          npm run lint
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: npm ci --ignore-scripts
+      - run: npm run build

--- a/src/Feature.tsx
+++ b/src/Feature.tsx
@@ -7,9 +7,6 @@ import InfoChip from "./InfoChip";
 import ChangeLogTable from "./ChangeLogTable";
 import WebsitesList from "./WebsitesList";
 
-// TypeScript compiler can't find types for turf, and declares the error below
-// seems like the fix will be included in an update by TurfJS team
-// see https://github.com/Turfjs/turf/issues/2307
 import bbox from "@turf/bbox";
 
 import Box from "@mui/material/Box";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,10 +2,13 @@
   "compilerOptions": {
     "target": "ES2020",
     "useDefineForClassFields": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": [
+      "ES2020",
+      "DOM",
+      "DOM.Iterable"
+    ],
     "module": "ESNext",
     "skipLibCheck": true,
-
     /* Bundler mode */
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
@@ -13,13 +16,19 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",
-
     /* Linting */
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["src"],
-  "references": [{ "path": "./tsconfig.node.json" }]
+  "include": [
+    "src",
+    "typings.d.ts"
+  ],
+  "references": [
+    {
+      "path": "./tsconfig.node.json"
+    }
+  ]
 }

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -1,0 +1,7 @@
+// TypeScript compiler can't find types for turf, and declares the error below
+// seems like the fix will be included in an update by TurfJS team
+// see https://github.com/Turfjs/turf/issues/2307
+declare module '@turf/bbox' {
+  const bbox: any;
+  export default bbox;
+}

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -2,6 +2,6 @@
 // seems like the fix will be included in an update by TurfJS team
 // see https://github.com/Turfjs/turf/issues/2307
 declare module '@turf/bbox' {
-  const bbox: any;
+  const bbox: BBox;
   export default bbox;
 }


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow named `CI Checks` that runs two jobs on every `push` event. The jobs, `lint` and `build`, are executed on an `ubuntu-latest` environment. The `lint` job checks out the code and runs the `lint` script, whereas the `build` job checks out the code, installs the dependencies, and then runs the `build` script. 

* [`.github/workflows/main.yml`](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3R1-R16): Added a new GitHub Actions workflow `CI Checks` that runs linting and build jobs on every push event.

The build step also shows an error with `turf/bbox` which I resolved. 