### PR TITLE
Force Map Start Position with URL searchParams

### DIFF
--- a/src/FrontPageMap.tsx
+++ b/src/FrontPageMap.tsx
@@ -6,6 +6,7 @@ import {
   MapLayerMouseEvent,
   Source,
 } from "react-map-gl";
+import { useSearchParams } from "react-router-dom";
 
 import Box from "@mui/system/Box";
 
@@ -53,7 +54,9 @@ const startingPositions = [
   { longitude: -68.5546875, latitude: -19.973348786110602 }, // pica, chile
 ];
 
-const getRandomStartingPosition = () => {
+const getRandomStartingCoordinates = () => {
+  // not entirely sure why this is necessary
+  // legacy code from the WordPress site
   if (window.innerWidth < 500) {
     return {
       longitude: -103.4216601,
@@ -124,13 +127,33 @@ export default function FrontPageMap({
   const hoveredFeatureNames = getFeatureNames(hoveredFeatures); // array of feature names for the hovered features' layer filter
   const selectedFeatureNames = getFeatureNames(selectedFeatures);
 
+  //  get the latitude and longitude from the URL search params
+  //    eg. http://native-land.ca/?longitude=-100.1953125&latitude=47.27922900257082
+  //  this was instated for testing purposes, so that we could force a load of the map at a specific location
+  const [searchParams] = useSearchParams();
+
+  const longitudeParam = searchParams.get("longitude");
+  const latitudeParam = searchParams.get("latitude");
+
+  // get the starting position for the map.
+  //   if the URL has a longitude and latitude, use that
+  //   otherwise, use a random starting position
+  const startingCoordinates =
+    longitudeParam && latitudeParam
+      ? {
+          longitude: Number(longitudeParam),
+          latitude: Number(latitudeParam),
+          zoom: 2.5,
+        }
+      : getRandomStartingCoordinates();
+
   return (
     <>
       <Map
         mapboxAccessToken={import.meta.env.VITE_MAPBOX_TOKEN}
         fog={{}} // defaults to starry background
         initialViewState={{
-          ...getRandomStartingPosition(),
+          ...startingCoordinates,
         }}
         interactiveLayerIds={["territories", mapboxTerritoriesTilesetName]}
         mapStyle={`mapbox://styles/nativeland/${


### PR DESCRIPTION
The base URL now accepts `latitude` and `longitude` params. 

For example, [entering as params the coordinates for North Dakota-ish](http://localhost:5173/?longitude=-100.1953125&latitude=47.27922900257082) yields:
<img width="898" alt="Screenshot 2024-04-15 at 7 48 06 PM" src="https://github.com/native-land-digital/native-land-web-client/assets/4361605/427702ef-d4f9-4535-8a10-39085a1ebda8">

The way I see it, **this is a prerequisite for any kind of visual testing that we would implement.** (see #9)

The way that visual tests work is that they compare a branch's changes with a baseline screenshot. So, `FrontPageMap` in both the branch test and the baseline screenshot must both be positioned at the same coordinates.